### PR TITLE
Fix selector for finding first name

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -1,7 +1,7 @@
 {
   "manifest_version": {{manifest_version}},
   "name": "arxivist",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",

--- a/src/arxivist.js
+++ b/src/arxivist.js
@@ -179,7 +179,7 @@
     for (var block_id = 0; block_id < blocks_length; ++block_id) {
       var block = blocks[block_id];
       var divs = block.getElementsByClassName('arxivist');
-      var old_first_name = divs[0].childNodes[0].childNodes[0].getAttribute('name');
+      var old_first_name = divs[0].querySelector("a[name]").getAttribute('name');
       var divs_length = divs.length;
       var sortable = [];
       for (var div_id = 0; div_id < divs_length; ++div_id) {


### PR DESCRIPTION
I changed the selector for finding the first name to not be dependent on whether a certain number of childNodes are present but target it more directly.

I think this will fix #3 (I've tested on Chrome at least).